### PR TITLE
feat: Ajust Features styles with round and gaps & better titles spacing

### DIFF
--- a/src/components/content-section.astro
+++ b/src/components/content-section.astro
@@ -9,7 +9,7 @@ const { title, id } = Astro.props;
 
 <section
   id={id}
-  class="flex scroll-mt-24 flex-col items-center gap-4 space-y-8"
+  class="flex scroll-mt-24 flex-col items-center gap-4 space-y-8 pb-9"
 >
   <div class="flex flex-col items-center gap-4">
     <slot name="eyebrow" />

--- a/src/components/features.astro
+++ b/src/components/features.astro
@@ -4,11 +4,17 @@ import ContentSection from "~/components/content-section.astro";
 import type { FeatureItem } from "~/types";
 
 const features: Array<FeatureItem> = [
-  {
-    title: "Community Plugin Ecosystem",
+{
+    title: "Fast Startup",
     description:
-      "Access to <a href='https://git.astronvim.com/AstroCommunity' class='hover:underline text-primary'>AstroCommunity</a>, an extensive community-maintained plugin marketplace that makes it easier than ever to add plugins or language support.",
-    icon: "tabler:box-seam",
+      "Fast startup time whether you are opening an empty Neovim session or opening a file directly through extensive lazy loading of plugins.",
+    icon: "tabler:rocket",
+  },
+  {
+    title: "Modular Configuration",
+    description:
+      "A modular configuration built as a collection of plugins which are configured like any other Neovim plugin without the need for esoteric configuration mechanisms.",
+    icon: "tabler:puzzle",
   },
   {
     title: "Automatic Tool Setup",
@@ -17,22 +23,16 @@ const features: Array<FeatureItem> = [
     icon: "tabler:settings",
   },
   {
-    title: "Fast Startup",
+    title: "Community Plugin Ecosystem",
     description:
-      "Fast startup time whether you are opening an empty Neovim session or opening a file directly through extensive lazy loading of plugins.",
-    icon: "tabler:rocket",
+      "Access to <a href='https://git.astronvim.com/AstroCommunity' class='hover:underline text-primary'>AstroCommunity</a>, an extensive community-maintained plugin marketplace that makes it easier than ever to add plugins or language support.",
+    icon: "tabler:box-seam",
   },
   {
     title: "Aesthetic User Interface",
     description:
       "A beautiful user interface that focuses on proividing the information you need without wasting space or cluttering the screen.",
     icon: "tabler:palette",
-  },
-  {
-    title: "Modular Configuration",
-    description:
-      "A modular configuration built as a collection of plugins which are configured like any other Neovim plugin without the need for esoteric configuration mechanisms.",
-    icon: "tabler:puzzle",
   },
   {
     title: "Stability Focused Development",
@@ -49,10 +49,10 @@ const features: Array<FeatureItem> = [
       class="text-primary">speed</span
     > or <span class="text-primary">customization</span>.
   </Fragment>
-  <ul class="grid max-w-6xl grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+  <ul class="grid max-w-6xl grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
     {
       features.map(({ title, description, icon }) => (
-        <li class="flex flex-col items-center gap-4 border border-default bg-offset p-6">
+        <li class="flex flex-col items-center gap-4 border border-default rounded-xl bg-offset p-6">
           <div class="h-16 w-16 rounded-full border-2 border-primary p-3">
             <Icon class="h-full w-full text-primary" name={icon} />
           </div>

--- a/src/components/features.astro
+++ b/src/components/features.astro
@@ -4,17 +4,11 @@ import ContentSection from "~/components/content-section.astro";
 import type { FeatureItem } from "~/types";
 
 const features: Array<FeatureItem> = [
-{
-    title: "Fast Startup",
-    description:
-      "Fast startup time whether you are opening an empty Neovim session or opening a file directly through extensive lazy loading of plugins.",
-    icon: "tabler:rocket",
-  },
   {
-    title: "Modular Configuration",
+    title: "Community Plugin Ecosystem",
     description:
-      "A modular configuration built as a collection of plugins which are configured like any other Neovim plugin without the need for esoteric configuration mechanisms.",
-    icon: "tabler:puzzle",
+      "Access to <a href='https://git.astronvim.com/AstroCommunity' class='hover:underline text-primary'>AstroCommunity</a>, an extensive community-maintained plugin marketplace that makes it easier than ever to add plugins or language support.",
+    icon: "tabler:box-seam",
   },
   {
     title: "Automatic Tool Setup",
@@ -23,16 +17,22 @@ const features: Array<FeatureItem> = [
     icon: "tabler:settings",
   },
   {
-    title: "Community Plugin Ecosystem",
+    title: "Fast Startup",
     description:
-      "Access to <a href='https://git.astronvim.com/AstroCommunity' class='hover:underline text-primary'>AstroCommunity</a>, an extensive community-maintained plugin marketplace that makes it easier than ever to add plugins or language support.",
-    icon: "tabler:box-seam",
+      "Fast startup time whether you are opening an empty Neovim session or opening a file directly through extensive lazy loading of plugins.",
+    icon: "tabler:rocket",
   },
   {
     title: "Aesthetic User Interface",
     description:
       "A beautiful user interface that focuses on proividing the information you need without wasting space or cluttering the screen.",
     icon: "tabler:palette",
+  },
+  {
+    title: "Modular Configuration",
+    description:
+      "A modular configuration built as a collection of plugins which are configured like any other Neovim plugin without the need for esoteric configuration mechanisms.",
+    icon: "tabler:puzzle",
   },
   {
     title: "Stability Focused Development",


### PR DESCRIPTION
## 📑 Description

I simply want to add a tiny touch to make things looks a bit nicer

- Add radius and gap to "Features" elements
- I arrange feature order to make the one line feature title with the others one line and the two lines feature title on the same line.
- Ajust general section spacing to add a bit more bottom spacing (Faq **was** a bit closer of "Features section" than "Faq" section) (Very very small ajustement)

## ℹ Additional Information

### Features section

#### Before:

<img width="1724" alt="image" src="https://github.com/AstroNvim/astronvim.com/assets/12479055/2b38b1e2-1067-495e-aa9d-3f43175e3d63">

#### After:

<img width="1724" alt="image" src="https://github.com/AstroNvim/astronvim.com/assets/12479055/0b896fad-c412-45c6-ae9e-9686bb4d12a3">

Looks nice on smaller screen and mobile too

<img width="490" alt="image" src="https://github.com/AstroNvim/astronvim.com/assets/12479055/4e57563e-ff22-468b-b73e-db71ab9fd718">

### Section spacing ajustement (Very very small ajustement)

#### Before

<img width="1724" alt="image" src="https://github.com/AstroNvim/astronvim.com/assets/12479055/95905e22-7528-43af-8c10-9856499f8673">

#### After

<img width="1724" alt="image" src="https://github.com/AstroNvim/astronvim.com/assets/12479055/fc37176d-655f-4c69-bece-8e269e037ff3">
