### PR TITLE
feat: add gradient border to hero image

### DIFF
--- a/src/components/intro.astro
+++ b/src/components/intro.astro
@@ -21,12 +21,17 @@ import { Image } from "astro:assets";
       <span>Get started</span>
     </a>
     <div class="mx-auto max-w-screen-2xl pt-8">
-      <Image
-        class="relative w-full rounded-lg border border-default"
-        id="overview-image"
-        src={astrodarkImage}
-        alt="AstroNvim Overview"
-      />
+      <div
+        class="relative rounded-lg bg-gradient-to-br from-[--color-gradient-from] via-[--color-gradient-via] to-[--color-gradient-to] p-[0.0625rem] md:p-1"
+      >
+        <Image
+          class="rounded-lg"
+          id="overview-image"
+          src={astrodarkImage}
+          alt="AstroNvim Overview"
+          loading="eager"
+        />
+      </div>
     </div>
   </ContentSection>
 </div>


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Use a gradient border for the hero image highlighting

![2023-10-23_20:19:54_screenshot](https://github.com/AstroNvim/astronvim.com/assets/1591837/afefb900-6e42-48ed-9c65-ba4ec1b828d6)


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
