### PR TITLE
fix: show pointer cursor on theme switcher button hover

### DIFF
--- a/src/components/theme-switcher.astro
+++ b/src/components/theme-switcher.astro
@@ -6,7 +6,7 @@ import { Icon } from "astro-icon/components";
   negative margin is sum of button width (8) and gap size of flex parent (6)
   TODO don't hardcode these values
 -->
-<button id="theme-switcher" type="button" class="ml-0 origin-(right_center)">
+<button id="theme-switcher" type="button" class="ml-0 origin-(right_center) cursor-pointer">
   <div id="icon-theme-auto">
     <Icon name="tabler:sun-moon" class="h-8 text-lg" />
     <span class="sr-only">Use dark theme</span>


### PR DESCRIPTION


## 📑 Description

Added `cursor-pointer` style to the theme switcher button so that the cursor changes to a pointer (hand) on hover. This improves the UI by making the button look clearly clickable.

### Changes:
- [x] Added `cursor-pointer` to the `class` attribute of the `#theme-switcher` button

## ℹ Additional Information

- **Type of change:** style (UI improvement)
- **Breaking changes:** none
- **New dependencies:** none
- **Behavior change:** the theme switcher button now shows a pointer cursor on hover

---

### 💬 Commit message
fix: show pointer cursor on theme switcher button hover
